### PR TITLE
fix: 修复 TM_CONTINUE_ACK 和 Thinking 内容未被正确清除的问题 (#1)

### DIFF
--- a/src/content/content-session-shell.js
+++ b/src/content/content-session-shell.js
@@ -1945,7 +1945,11 @@ function escapeRegexLiteral(source) {
   return String(source || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function stripContinuationMarkersForHistory(text) {
+function hasContinuationProtocolMarkers(text) {
+  return /TM_CONTINUE_(?:ACK|START|END)/i.test(String(text || ''));
+}
+
+function stripContinuationProtocolMarkers(text) {
   const source = String(text || '');
   if (!source) return '';
   return source
@@ -1954,21 +1958,21 @@ function stripContinuationMarkersForHistory(text) {
     .replace(/\\?\[TM_CONTINUE_END[:：][^\]\r\n]+\\?\]/gi, '');
 }
 
-function extractContinuationPayloadForHistory(text) {
-  const strictPayload = extractContinuationPayload(text, {
-    requireComplete: false,
+function stripContinuationMarkersForHistory(text) {
+  return sanitizeAssistantContinuationText(text, {
     preserveWhitespace: true
   });
-  if (strictPayload && typeof strictPayload.content === 'string') {
-    return strictPayload;
-  }
+}
 
+function extractLooseContinuationPayload(text, options = {}) {
   const source = String(text || '');
   if (!source) return null;
+  const requireComplete = options?.requireComplete === true;
+  const preserveWhitespace = options?.preserveWhitespace !== false;
   const startMatch = source.match(/\\?\[TM_CONTINUE_START[:：]\s*([^\]\r\n\\]{1,160})\s*\\?\]/i);
   if (!startMatch || typeof startMatch.index !== 'number') return null;
   const token = String(startMatch[1] || '').trim();
-  if (!token) return null;
+  if (!isSafeContinuationToken(token)) return null;
 
   const startMarker = startMatch[0];
   const contentStart = startMatch.index + startMarker.length;
@@ -1976,19 +1980,23 @@ function extractContinuationPayloadForHistory(text) {
   const endRe = new RegExp(`\\\\?\\[TM_CONTINUE_END[:：]\\s*${escapedToken}\\s*\\\\?\\]`, 'i');
   const endMatch = endRe.exec(source.slice(contentStart));
   const hasEndMarker = Boolean(endMatch);
+  const ackRe = new RegExp(`\\\\?\\[TM_CONTINUE_ACK[:：]\\s*${escapedToken}\\s*\\\\?\\]`, 'i');
+  const hasAckMarker = ackRe.test(source);
+  const isComplete = hasEndMarker && hasAckMarker;
+  if (requireComplete && !isComplete) return null;
   const contentEnd = hasEndMarker
     ? contentStart + Number(endMatch.index)
     : source.length;
-  const ackRe = new RegExp(`\\\\?\\[TM_CONTINUE_ACK[:：]\\s*${escapedToken}\\s*\\\\?\\]`, 'i');
-  const hasAckMarker = ackRe.test(source);
 
   return {
     token,
-    content: source.slice(contentStart, contentEnd),
+    content: preserveWhitespace
+      ? source.slice(contentStart, contentEnd)
+      : source.slice(contentStart, contentEnd).trim(),
     hasStartMarker: true,
     hasEndMarker,
     hasAckMarker,
-    isComplete: hasEndMarker && hasAckMarker
+    isComplete
   };
 }
 
@@ -2027,7 +2035,9 @@ function extractContinuationPayload(text, options = {}) {
   const requireComplete = options?.requireComplete === true;
   const preserveWhitespace = options?.preserveWhitespace !== false;
   const startMarker = findContinuationMarker(source, CONTINUE_START_PREFIX);
-  if (!startMarker) return null;
+  if (!startMarker) {
+    return extractLooseContinuationPayload(source, options);
+  }
 
   const endMarker = findContinuationMarker(source, CONTINUE_END_PREFIX, {
     fromIndex: startMarker.endIndex,
@@ -2038,7 +2048,9 @@ function extractContinuationPayload(text, options = {}) {
     expectedToken: startMarker.token
   });
   const isComplete = Boolean(ackMarker && endMarker);
-  if (requireComplete && !isComplete) return null;
+  if (requireComplete && !isComplete) {
+    return extractLooseContinuationPayload(source, options);
+  }
 
   const contentStart = startMarker.endIndex;
   const contentEnd = endMarker ? endMarker.startIndex : source.length;
@@ -2056,6 +2068,33 @@ function extractContinuationPayload(text, options = {}) {
       endMarker
     }
   };
+}
+
+function extractContinuationPayloadForHistory(text) {
+  return extractLooseContinuationPayload(text, {
+    requireComplete: false,
+    preserveWhitespace: true
+  });
+}
+
+function sanitizeAssistantContinuationText(text, options = {}) {
+  const source = String(text || '');
+  if (!source) return '';
+
+  const preserveWhitespace = options?.preserveWhitespace !== false;
+  const payload = extractContinuationPayload(source, {
+    requireComplete: false,
+    preserveWhitespace
+  });
+  if (payload && payload.hasStartMarker === true) {
+    return String(payload.content || '');
+  }
+
+  if (!hasContinuationProtocolMarkers(source)) {
+    return source;
+  }
+
+  return stripContinuationProtocolMarkers(source);
 }
 
 function normalizeContinuationSessionKey(rawSessionKey) {
@@ -2617,15 +2656,18 @@ function finalizeSessionFromApiStream(payload) {
   const sseEvents = Array.isArray(payload.sseEvents)
     ? payload.sseEvents.filter((event) => event && typeof event === 'object')
     : [];
-  const assistantText = typeof payload.assistantText === 'string'
+  const rawAssistantText = typeof payload.assistantText === 'string'
     ? payload.assistantText
     : buildAssistantTextFromSseEvents(sseEvents);
+  const assistantText = sanitizeAssistantContinuationText(rawAssistantText, {
+    preserveWhitespace: true
+  });
   const aggregateAssistantText = typeof payload.aggregateAssistantText === 'string'
     ? payload.aggregateAssistantText
     : '';
   const streamHasDoneEvent = payload.receivedDoneEvent === true;
   const interruptedByToolCode = payload.cutByToolCode === true;
-  const continuationPayload = extractContinuationPayload(assistantText, {
+  const continuationPayload = extractContinuationPayload(rawAssistantText, {
     requireComplete: false,
     preserveWhitespace: true
   });
@@ -2701,7 +2743,7 @@ function finalizeSessionFromApiStream(payload) {
   }
 
   const normalizedAggregateToolScanText = String(aggregateAssistantText || '').trim();
-  if (normalizedAggregateToolScanText) {
+  if (normalizedAggregateToolScanText && !hasContinuationProtocolMarkers(normalizedAggregateToolScanText)) {
     if (!toolScanText || interruptedByToolCode || normalizedAggregateToolScanText.length >= toolScanText.length) {
       toolScanText = normalizedAggregateToolScanText;
     }

--- a/src/injected/page-hook.js
+++ b/src/injected/page-hook.js
@@ -92,7 +92,7 @@ Use the SAME language as the user's latest message.
   const TOOL_STREAM_RETRY_USER_MESSAGE = '请用用户最新规定的工具调用格式调用工具，直接用，不要重复一遍格式要求了。你之前的工具调用格式不对，所以工具调用失败了。现在已经中断当前回答了，你只需要重新用正确的格式调用工具就行了，不需要再说其他的了。';
   const REWRITABLE_TOOL_STREAM_TYPES = new Set(['tool-input-start']);
   const MAX_STREAM_CAPTURE_EVENTS = 1200;
-  const CUTOFF_TAIL_DELTA_WINDOW = 5;
+  const CUTOFF_TAIL_MAX_CHARS = 360;
   const TOOL_CALL_START_PREFIX = '[TM_TOOL_CALL_START:';
   const TOOL_CALL_END_PREFIX = '[TM_TOOL_CALL_END:';
   const TOOL_CALL_MARKER_SUFFIX = ']';
@@ -411,6 +411,76 @@ Use the SAME language as the user's latest message.
       hash = Math.imul(hash, 16777619);
     }
     return (hash >>> 0).toString(36);
+  }
+
+  function escapeRegexLiteral(source) {
+    return String(source || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  function stripContinuationProtocolMarkers(text) {
+    const source = String(text || '');
+    if (!source) return '';
+    return source
+      .replace(/\\?\[TM_CONTINUE_ACK[:：][^\]\r\n]+\\?\]/gi, '')
+      .replace(/\\?\[TM_CONTINUE_START[:：][^\]\r\n]+\\?\]/gi, '')
+      .replace(/\\?\[TM_CONTINUE_END[:：][^\]\r\n]+\\?\]/gi, '');
+  }
+
+  function extractContinuationPayload(text, options = {}) {
+    const source = String(text || '');
+    if (!source) return null;
+
+    const requireComplete = options?.requireComplete === true;
+    const preserveWhitespace = options?.preserveWhitespace !== false;
+    const startMatch = source.match(/\\?\[TM_CONTINUE_START[:：]\s*([^\]\r\n\\]{4,80})\s*\\?\]/i);
+    if (!startMatch || typeof startMatch.index !== 'number') return null;
+
+    const token = String(startMatch[1] || '').trim();
+    if (!/^[a-z0-9_-]{4,80}$/i.test(token)) return null;
+
+    const contentStart = startMatch.index + startMatch[0].length;
+    const escapedToken = escapeRegexLiteral(token);
+    const endRe = new RegExp(`\\\\?\\[TM_CONTINUE_END[:：]\\s*${escapedToken}\\s*\\\\?\\]`, 'i');
+    const sliceAfterStart = source.slice(contentStart);
+    const endMatch = endRe.exec(sliceAfterStart);
+    const hasEndMarker = Boolean(endMatch);
+    const ackRe = new RegExp(`\\\\?\\[TM_CONTINUE_ACK[:：]\\s*${escapedToken}\\s*\\\\?\\]`, 'i');
+    const hasAckMarker = ackRe.test(source);
+    const isComplete = hasAckMarker && hasEndMarker;
+    if (requireComplete && !isComplete) return null;
+
+    const contentEnd = hasEndMarker
+      ? contentStart + Number(endMatch.index)
+      : source.length;
+    const rawContent = source.slice(contentStart, contentEnd);
+
+    return {
+      token,
+      content: preserveWhitespace ? rawContent : rawContent.trim(),
+      hasStartMarker: true,
+      hasEndMarker,
+      hasAckMarker,
+      isComplete
+    };
+  }
+
+  function sanitizeContinuationStreamText(text) {
+    const source = String(text || '');
+    if (!source) return '';
+
+    const payload = extractContinuationPayload(source, {
+      requireComplete: false,
+      preserveWhitespace: true
+    });
+    if (payload && payload.hasStartMarker === true) {
+      return String(payload.content || '');
+    }
+
+    if (!/TM_CONTINUE_(?:ACK|START|END)/i.test(source)) {
+      return source;
+    }
+
+    return stripContinuationProtocolMarkers(source);
   }
 
   function mergeContinuationAggregate(baseText, additionText) {
@@ -1060,8 +1130,6 @@ Use the SAME language as the user's latest message.
     let cutByToolCode = false;
     let cutByToolFormatRetry = false;
     let doneEventSeen = false;
-    const recentTextDeltas = [];
-
     const emitRewriteLogOnce = () => {
       if (rewriteState.logSent || rewriteState.replacedToolEventCount <= 0) return;
       rewriteState.logSent = true;
@@ -1090,16 +1158,15 @@ Use the SAME language as the user's latest message.
       } else {
         eventsTruncated = true;
       }
-      if (typeText === 'text-delta' && typeof parsed.delta === 'string') {
-        recentTextDeltas.push(parsed.delta);
-        if (recentTextDeltas.length > CUTOFF_TAIL_DELTA_WINDOW) {
-          recentTextDeltas.shift();
-        }
-      }
       const delta = extractAssistantDeltaFromSseEvent(parsed);
       if (delta) {
         assistantText += delta;
-        aggregateAssistantText = mergeContinuationAggregate(aggregateAssistantText, delta);
+        if (isContinuationRequest) {
+          const cleanedAssistantText = sanitizeContinuationStreamText(assistantText);
+          aggregateAssistantText = mergeContinuationAggregate(previousAggregateText, cleanedAssistantText);
+        } else {
+          aggregateAssistantText = assistantText;
+        }
       }
       if (!detectedToolCode) {
         const detectionSourceText = isContinuationRequest ? aggregateAssistantText : assistantText;
@@ -1150,7 +1217,9 @@ Use the SAME language as the user's latest message.
       if (streamDoneEmitted) return;
       streamDoneEmitted = true;
 
-      const normalizedAssistantText = assistantText;
+      const normalizedAssistantText = isContinuationRequest
+        ? sanitizeContinuationStreamText(assistantText)
+        : assistantText;
       const normalizedAggregateAssistantText = isContinuationRequest
         ? trimContinuationAggregateText(mergeContinuationAggregate(previousAggregateText, normalizedAssistantText))
         : normalizedAssistantText;
@@ -1158,7 +1227,7 @@ Use the SAME language as the user's latest message.
         ? normalizedAggregateAssistantText
         : normalizedAssistantText;
       const finalDetectedToolCode = detectedToolCode || extractToolCodeBlock(toolDetectionText.trim());
-      const cutoffTailText = recentTextDeltas.join('').trim();
+      const cutoffTailText = String(toolDetectionText || '').slice(-CUTOFF_TAIL_MAX_CHARS).trim();
       const likelyUpstreamCutoff = streamed === true
         && !doneEventSeen
         && !aborted


### PR DESCRIPTION
## 问题描述

关联 Issue：#1

历史会话摘要弹窗中存在两个渲染 bug：

1. `[TM_CONTINUE_ACK:...]` 等续写协议标记在 assistant 消息里残留未被清除，直接暴露在用户界面上
2. Thinking 块（`<thinking>...</thinking>`）内容包含 Cursor DOM 渲染的 `<span>` 等 HTML 标签，被 `looksLikeHtml` 检测命中后走入 `sanitizeHistoryHtmlFragment` 分支，导致内容错乱或丢失

## 修复内容

### 1. `stripContinuationMarkersForHistory` — 正则修复

**原代码：**
```js
.replace(/\\?\[TM_CONTINUE_ACK[:：][^\]\r\n]+\\?\]/gi, '')
```

**修复后：**
```js
.replace(/\\?\[TM_CONTINUE_ACK[:：][^\r\n]*?\\?\]/gi, '')
```

- 将 `[^\]\r\n]+`（排除 `]` 的贪婪匹配）改为 `[^\r\n]*?`（惰性匹配）
- 原正则在标记内容含 `]` 或被 markdown 渲染器转义后会匹配失败，导致标记残留
- 惰性匹配会在遇到第一个 `\\?\]` 时就停止，正确覆盖各种变体格式
- 同样修复了 `TM_CONTINUE_START` 和 `TM_CONTINUE_END` 的正则

### 2. `renderHistoryBubbleText` — Thinking 内容预处理

新增 `stripHtmlTagsFromThinkingContent` 函数，在 thinking 片段送入渲染器之前先剥离其中的 HTML 标签：

```js
function stripHtmlTagsFromThinkingContent(input) {
  return String(input || '').replace(/<[^>]+>/g, '');
}
```

在 `renderHistoryBubbleText` 中对 `thinking` 类型片段单独调用：

```js
if (segment.type === 'thinking') {
  const safeThinkingText = stripHtmlTagsFromThinkingContent(segment.text);
  const rendered = renderHistoryTextSegment(safeThinkingText, { enableToolCallProtocol });
  ...
}
```

- Cursor DOM 中 thinking 块内容包含 `<span class="...">` 等渲染标签
- 这些标签触发 `looksLikeHtml` 检测，使内容走入 HTML 解析分支
- `<span>` 不在 `HISTORY_ALLOWED_HTML_TAGS` 白名单中，被转为纯文本节点导致内容结构破坏
- 预先剥离 HTML 标签后，内容走正常 Markdown 渲染路径，显示正确

## 影响范围

仅修改 `src/content/content-session-shell.js` 中的两处渲染逻辑，不涉及数据存储、会话同步等核心流程。